### PR TITLE
Fix outdated values in infra (vault) helmfile.yaml

### DIFF
--- a/infra/helmfile.yaml
+++ b/infra/helmfile.yaml
@@ -3,17 +3,18 @@ namespace: jx-vault
 repositories:
 - name: banzaicloud-stable
   url: https://kubernetes-charts.banzaicloud.com
-- name: jx3
-  url: https://storage.googleapis.com/jenkinsxio/charts
+- name: jxgh
+  url: https://jenkins-x-charts.github.io/repo
 releases:
 - chart: banzaicloud-stable/vault-operator
   name: vault-operator
-  version: 1.10.0
+  version: 1.19.0
   forceNamespace: ""
+  disableValidation: true
   skipDeps: null
 - chart: jx3/vault-instance
   name: vault-instance
-  version: 1.0.15
+  version: 1.0.27
   forceNamespace: ""
   skipDeps: null
 templates: {}


### PR DESCRIPTION
The current version of the infra/helmfile.yaml is failing to due to various out of date configuration.

The following changes allowed me get the jx-vault installed on our on-premises k8s cluster (v1.27.4)