### PR TITLE
fix: replace broken helm repository, upgrade bank-vault and vault

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- maintainers
+reviewers:
+- maintainers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,3 @@
+foreignAliases:
+- name: jx-community
+  org: jenkins-x

--- a/infra/helmfile.yaml
+++ b/infra/helmfile.yaml
@@ -1,19 +1,24 @@
 filepath: ""
 namespace: jx-vault
 repositories:
-- name: banzaicloud-stable
-  url: https://kubernetes-charts.banzaicloud.com
-- name: jx3
-  url: https://storage.googleapis.com/jenkinsxio/charts
+- name: bank-vaults
+  url: ghcr.io/bank-vaults/helm-charts
+  oci: true
+- name: jxgh
+  url: https://jenkins-x-charts.github.io/repo
 releases:
-- chart: banzaicloud-stable/vault-operator
+- chart: bank-vaults/vault-operator
   name: vault-operator
-  version: 1.10.0
+  version: 1.22.3
   forceNamespace: ""
   skipDeps: null
-- chart: jx3/vault-instance
+- chart: jxgh/vault-instance
+  version: 1.0.28
   name: vault-instance
-  version: 1.0.15
+  values:
+  - bankVaultsImage: ghcr.io/bank-vaults/bank-vaults:v1.31.2
+    ingress:
+      enabled: false
   forceNamespace: ""
   skipDeps: null
 templates: {}


### PR DESCRIPTION
Part of fix for jenkins-x/jx#8688

If this is approved I will apply the same fix in [jx3-gitops-repositories/jx3-docker-vault](https://github.com/jx3-gitops-repositories/jx3-docker-vault)

(Not that I know whether any of these repositories are used...)